### PR TITLE
[MRG] fix: incr drive time for tutorial spect plot

### DIFF
--- a/network-configurations/gamma_L5weak_L2weak.json
+++ b/network-configurations/gamma_L5weak_L2weak.json
@@ -3966,7 +3966,7 @@
             "conn_seed": 3,
             "dynamics": {
                 "tstart": 0,
-                "tstop": 250.0,
+                "tstop": 300.0,
                 "rate_constant": {
                     "L2_basket": 1,
                     "L2_pyramidal": 140.0,


### PR DESCRIPTION
This addresses one of the subtasks of https://github.com/jonescompneurolab/hnn-tutorials/issues/17 