### PR TITLE
Increase gamma tut weak drive tstop for spect

### DIFF
--- a/workshops/gamma_gui_walkthrough/gamma_L5weak_L2weak.json
+++ b/workshops/gamma_gui_walkthrough/gamma_L5weak_L2weak.json
@@ -3966,7 +3966,7 @@
             "conn_seed": 3,
             "dynamics": {
                 "tstart": 0,
-                "tstop": 250.0,
+                "tstop": 300.0,
                 "rate_constant": {
                     "L2_basket": 1,
                     "L2_pyramidal": 140.0,


### PR DESCRIPTION
This is necessary because a simulation time of 250 is too short for our spectrogramming configuration. See
https://github.com/jonescompneurolab/hnn-core/pull/944